### PR TITLE
removed unnecessary steps to install packages

### DIFF
--- a/scripts/squid/basic.sh
+++ b/scripts/squid/basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config build-essential autoconf apache2-utils
+sudo apt-get update && sudo apt-get upgrade -y
 
 wget http://www.squid-cache.org/Versions/v4/squid-4.12.tar.gz 
 tar xvzf squid-4.12.tar.gz

--- a/scripts/squid/cert.sh
+++ b/scripts/squid/cert.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config build-essential autoconf
+sudo apt-get update && sudo apt-get upgrade -y
 
 wget http://www.squid-cache.org/Versions/v4/squid-4.12.tar.gz 
 tar xvzf squid-4.12.tar.gz

--- a/scripts/squid/noauth.sh
+++ b/scripts/squid/noauth.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config build-essential autoconf
+sudo apt-get update && sudo apt-get upgrade -y
 
 wget http://www.squid-cache.org/Versions/v4/squid-4.12.tar.gz 
 tar xvzf squid-4.12.tar.gz


### PR DESCRIPTION
The  package sources directly from deb main have been restricted in azure vm. Hence the packages build-essential , pkg-config,  etc were not getting installed. We don't need to explicity install now them now as doing a apt-get upgrade will install them